### PR TITLE
docs: setting up rtd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/source/generated/*
 
 # PyBuilder
 .pybuilder/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,28 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,3 +26,6 @@ sphinx:
 python:
    install:
    - requirements: docs/requirements.txt
+    # Install our python package before building the docs
+    - method: pip
+      path: .

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx==7.1.2
+sphinx-rtd-theme==1.3.0rc1

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -4,4 +4,33 @@ API
 .. autosummary::
    :toctree: generated
 
-   rna_sdb
+
+Datasets
+--------
+
+.. automodule:: rna_sdb.datasets
+
+
+.. autoclass:: rna_sdb.datasets.RNASDB
+  :members:
+
+.. automethod:: rna_sdb.datasets.load_archiveII
+
+
+TODO more to be added!
+
+
+
+utils
+-----
+
+
+.. automodule:: rna_sdb.utils 
+
+
+.. automethod:: rna_sdb.utils.read_fasta
+
+.. automethod:: rna_sdb.utils.write_fasta
+
+
+TODO more to be added!

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,7 @@
+API
+===
+
+.. autosummary::
+   :toctree: generated
+
+   rna_sdb

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,35 @@
+# Configuration file for the Sphinx documentation builder.
+
+# -- Project information
+
+project = 'rna_sdb'
+copyright = 'abc'
+author = 'abc'
+
+release = '0.1'
+version = '0.1.0'
+
+# -- General configuration
+
+extensions = [
+    'sphinx.ext.duration',
+    'sphinx.ext.doctest',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.intersphinx',
+]
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
+}
+intersphinx_disabled_domains = ['std']
+
+templates_path = ['_templates']
+
+# -- Options for HTML output
+
+html_theme = 'sphinx_rtd_theme'
+
+# -- Options for EPUB output
+epub_show_urls = 'footnote'

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,10 @@
+Test!
+=====
+
+
+Contents
+--------
+
+.. toctree::
+
+   api

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -1,0 +1,19 @@
+Getting started
+===============
+
+
+
+Installation
+------------
+
+TODO
+
+
+
+Example: evaluate model using RNA-SDB dataset
+---------------------------------------------
+
+
+TODO
+
+


### PR DESCRIPTION
I don't have enough permission in this repo to enable webhook for readthedocs's PR preview. I think this has to be merged to `main` to be visible on readthedocs: https://readthedocs.org/projects/rna-sdb/. 

Doc build tested locally and it's working - but I don't know whether it works on readthedocs so I'd like to merge and test. 
![image](https://github.com/user-attachments/assets/9d3ee213-19d2-4736-a0af-fc0e92c81143)
